### PR TITLE
Add View interface for Qt application to use

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,9 @@ pkgconfig_DATA += mathview-backend-qt.pc
 endif
 if HAVE_LIBXML2
 pkgconfig_DATA += gtkmathview-libxml2.pc
+if HAVE_QT
+pkgconfig_DATA += mathview-widget-qt.pc
+endif
 endif
 if HAVE_LIBXML2_READER
 pkgconfig_DATA += gtkmathview-libxml2-reader.pc

--- a/configure.ac
+++ b/configure.ac
@@ -217,6 +217,7 @@ AC_CONFIG_FILES([
  mathview-frontend-libxml2.pc
  mathview-backend-cairo.pc
  mathview-backend-qt.pc
+ mathview-widget-qt.pc
  gtkmathview-custom-reader.pc
  gtkmathview-libxml2-reader.pc
  gtkmathview-libxml2.pc

--- a/mathview-widget-qt.pc.in
+++ b/mathview-widget-qt.pc.in
@@ -1,0 +1,15 @@
+# This is a comment
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+datarootdir=@datarootdir@
+datadir=@datadir@
+
+Name: MathView
+Description: MathML rendering engine QPainter-based widgets
+Version: @PACKAGE_VERSION@
+Requires: Qt5Widgets mathview-core mathview-backend-qt mathview-frontend-libxml2
+Libs: @XML_LIBS@ -L${libdir} -lmathview_widget_qt
+Cflags: @XML_CFLAGS@ -I${includedir}/@PACKAGE@
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -561,6 +561,27 @@ libgtkmathview_libxml2_la_LIBADD = \
   libmathview_frontend_libxml2.la \
   $(NULL)
 endif # HAVE_GTK
+
+if HAVE_QT
+moc_%.cc: %.hh
+	$(MOC) $< -o $@
+
+lib_LTLIBRARIES += libmathview_widget_qt.la
+libmathview_widget_qt_la_SOURCES = \
+  widget/QMathView.cc \
+  widget/moc_QMathView.cc \
+  $(NULL)
+
+libmathview_widget_qt_la_LDFLAGS = -version-info @MATHVIEW_VERSION_INFO@
+libmathview_widget_qt_la_LIBADD = \
+  $(QT_LIBS) \
+  $(NULL)
+
+qtdir = $(includedir)/$(PACKAGE)/
+qt_HEADERS = \
+  widget/QMathView.hh \
+  $(NULL)
+endif # HAVE_QT
 endif # HAVE_LIBXML2
 
 
@@ -611,6 +632,7 @@ AM_CPPFLAGS = \
   -I$(top_srcdir)/src/common \
   -I$(top_srcdir)/src/view \
   -I$(top_srcdir)/src/backend/cairo \
+  -I$(top_srcdir)/src/backend/qt \
   -I$(top_srcdir)/src/backend \
   -I$(top_srcdir)/src/engine \
   -I$(top_srcdir)/src/frontend/common \

--- a/src/widget/QMathView.cc
+++ b/src/widget/QMathView.cc
@@ -41,7 +41,11 @@ typedef libxml2_MathView MathView;
 class QMathViewLogger : public AbstractLogger
 {
 public:
+#if QT_VERSION >= 0x050300
     QMathViewLogger(const QLoggingCategory& category)
+#else
+    QMathViewLogger(QLoggingCategory& category)
+#endif
         : AbstractLogger()
         , m_category(category)
     {}
@@ -54,15 +58,24 @@ protected:
             qCCritical(m_category) << log;
         } else if (m_category.isWarningEnabled() && log.startsWith("[MathView] *** Warning")) {
             qCWarning(m_category) << log;
+#if QT_VERSION >= 0x050500
         } else if (m_category.isInfoEnabled() && log.startsWith("[MathView] *** Info")) {
             qCInfo(m_category) << log;
+#else
+        } else if (m_category.isDebugEnabled() && log.startsWith("[MathView] *** Info")) {
+            qCDebug(m_category) << log;
+#endif
         } else if (m_category.isDebugEnabled() && log.startsWith("[MathView] *** Debug")) {
             qCDebug(m_category) << log;
         }
     }
 
 private:
+#if QT_VERSION >= 0x050300
     const QLoggingCategory& m_category;
+#else
+    QLoggingCategory& m_category;
+#endif
 };
 
 class QMathViewPrivate
@@ -79,7 +92,11 @@ public:
     RGBColor m_backgroundColor;
 };
 
+#if QT_VERSION >= 0x050300
 QMathView::QMathView(const QFont& font, const QLoggingCategory& category)
+#else
+QMathView::QMathView(const QFont& font, QLoggingCategory& category)
+#endif
     : d(new QMathViewPrivate())
 {
     d->m_rawFont = QRawFont::fromFont(font);
@@ -123,6 +140,7 @@ void QMathView::setFont(const QFont& font) {
         d->m_view, d->m_backend->getMathGraphicDevice()
     ));
 }
+
 void QMathView::update(QPainter* painter) {
     d->m_rc.setPainter(painter);
     d->m_view->render(d->m_rc, scaled::zero(), -d->m_view->getBoundingBox().height);

--- a/src/widget/QMathView.cc
+++ b/src/widget/QMathView.cc
@@ -1,0 +1,132 @@
+// Copyright (C) 2015 Yue Liu <yue.liu@mail.com>.
+//
+// This file is part of GtkMathView, a flexible, high-quality rendering
+// engine for MathML documents.
+//
+// GtkMathView is free software; you can redistribute it and/or modify it
+// either under the terms of the GNU Lesser General Public License version
+// 3 as published by the Free Software Foundation (the "LGPL") or, at your
+// option, under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation (the "GPL").  If you do not
+// alter this notice, a recipient may use your version of this file under
+// either the GPL or the LGPL.
+//
+// GtkMathView is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the LGPL or
+// the GPL for more details.
+//
+// You should have received a copy of the LGPL and of the GPL along with
+// this program in the files COPYING-LGPL-3 and COPYING-GPL-2; if not, see
+// <http://www.gnu.org/licenses/>.
+
+#include "QMathView.hh"
+
+#include "defs.h"
+#include "libxml2_MathView.hh"
+#include "AbstractLogger.hh"
+#include "MathMLOperatorDictionary.hh"
+#include "Qt_Backend.hh"
+#include "MathGraphicDevice.hh"
+#include "MathMLNamespaceContext.hh"
+#include "FormattingContext.hh"
+#include "Qt_RenderingContext.hh"
+
+#include <QPainter>
+#include <QRawFont>
+#include <QDebug>
+
+typedef libxml2_MathView MathView;
+
+class QMathViewLogger : public AbstractLogger
+{
+public:
+    QMathViewLogger(QDebug& error, QDebug& warning, QDebug& info, QDebug& debug)
+        : AbstractLogger()
+        , m_error(error)
+        , m_warning(warning)
+        , m_info(info)
+        , m_debug(debug)
+    {}
+    ~QMathViewLogger(){}
+
+protected:
+    virtual void outString(const String& str) const {
+        QString log = QString::fromStdString(str);
+        if (log.startsWith("[MathView] *** Error")) {
+            m_error << log;
+        } else if (log.startsWith("[MathView] *** Warning")) {
+            m_warning << log;
+        } else if (log.startsWith("[MathView] *** Info")) {
+            m_info << log;
+        } else if (log.startsWith("[MathView] *** Debug")) {
+            m_debug << log;
+        }
+    }
+
+private:
+    QDebug& m_error;
+    QDebug& m_warning;
+    QDebug& m_info;
+    QDebug& m_debug;
+};
+
+class QMathViewPrivate
+{
+public:
+    QMathViewPrivate(){}
+    ~QMathViewPrivate(){}
+
+    SmartPtr<Backend> m_backend;
+    SmartPtr<MathView> m_view;
+    Qt_RenderingContext m_rc;
+    QRawFont m_rawFont;
+};
+
+QMathView::QMathView(const QFont& font,
+                     QDebug& error, QDebug& warning, QDebug& info, QDebug& debug)
+    : d(new QMathViewPrivate())
+{
+    d->m_rawFont = QRawFont::fromFont(font);
+    d->m_backend = Qt_Backend::create(d->m_rawFont);
+    d->m_view = MathView::create(new QMathViewLogger(error, warning, info, debug));
+    d->m_view->setOperatorDictionary(MathMLOperatorDictionary::create());
+    d->m_view->setMathMLNamespaceContext(MathMLNamespaceContext::create(
+        d->m_view, d->m_backend->getMathGraphicDevice()
+    ));
+    d->m_view->setDefaultFontSize(DEFAULT_FONT_SIZE);
+}
+
+QMathView::~QMathView()
+{
+    d->m_view->resetRootElement();
+    delete d;
+}
+
+void QMathView::loadURI(const char* mathml_url) {
+    d->m_view->loadURI(mathml_url);
+}
+
+void QMathView::loadBuffer(const char* mathml_buf) {
+    d->m_view->loadBuffer(mathml_buf);
+}
+
+void QMathView::setFont(const QFont& font) {
+    d->m_rawFont = QRawFont::fromFont(font);
+    d->m_backend = Qt_Backend::create(d->m_rawFont);
+    d->m_view->setMathMLNamespaceContext(MathMLNamespaceContext::create(
+        d->m_view, d->m_backend->getMathGraphicDevice()
+    ));
+}
+void QMathView::update(QPainter* painter) {
+    d->m_rc.setPainter(painter);
+    d->m_view->render(d->m_rc, scaled::zero(), -d->m_view->getBoundingBox().height);
+}
+
+QSizeF QMathView::sizeF() const {
+    const BoundingBox box = d->m_view->getBoundingBox();
+    qreal width = Qt_RenderingContext::toQtPixels(box.horizontalExtent());
+    qreal height = Qt_RenderingContext::toQtPixels(box.verticalExtent());
+    //qDebug() << width << height;
+    return QSizeF(width, height);
+}

--- a/src/widget/QMathView.cc
+++ b/src/widget/QMathView.cc
@@ -31,6 +31,7 @@
 #include "MathMLNamespaceContext.hh"
 #include "FormattingContext.hh"
 #include "Qt_RenderingContext.hh"
+#include "RGBColor.hh"
 
 #include <QPainter>
 #include <QRawFont>
@@ -74,6 +75,8 @@ public:
     SmartPtr<MathView> m_view;
     Qt_RenderingContext m_rc;
     QRawFont m_rawFont;
+    RGBColor m_foregroundColor;
+    RGBColor m_backgroundColor;
 };
 
 QMathView::QMathView(const QFont& font, const QLoggingCategory& category)
@@ -101,6 +104,16 @@ void QMathView::loadURI(const char* mathml_url) {
 
 void QMathView::loadBuffer(const char* mathml_buf) {
     d->m_view->loadBuffer(mathml_buf);
+}
+
+void QMathView::setForegroundColor(const QColor& color) {
+    d->m_foregroundColor = RGBColor(color.red(), color.green(), color.blue(), color.alpha());
+    d->m_rc.setForegroundColor(d->m_foregroundColor);
+}
+
+void QMathView::setBackgroundColor(const QColor& color) {
+    d->m_backgroundColor = RGBColor(color.red(), color.green(), color.blue(), color.alpha());
+    d->m_rc.setBackgroundColor(d->m_backgroundColor);
 }
 
 void QMathView::setFont(const QFont& font) {

--- a/src/widget/QMathView.hh
+++ b/src/widget/QMathView.hh
@@ -23,9 +23,10 @@
 #ifndef QMathView_hh
 #define QMathView_hh
 
-#include <QtCore/QSizeF>
+#include <QSizeF>
 #include <QLoggingCategory>
 #include <QColor>
+#include <QtGlobal>
 
 class QMathViewPrivate;
 class QPainter;
@@ -33,7 +34,11 @@ class QPainter;
 class QMathView
 {
 public:
+#if QT_VERSION >= 0x050300
     QMathView(const QFont& font, const QLoggingCategory& category);
+#else
+    QMathView(const QFont& font, QLoggingCategory& category);
+#endif
     ~QMathView();
     void loadURI(const char* mathml_url);
     void loadBuffer(const char* mathml_buf);

--- a/src/widget/QMathView.hh
+++ b/src/widget/QMathView.hh
@@ -24,7 +24,7 @@
 #define QMathView_hh
 
 #include <QtCore/QSizeF>
-#include <QDebug>
+#include <QLoggingCategory>
 
 class QMathViewPrivate;
 class QPainter;
@@ -32,8 +32,7 @@ class QPainter;
 class QMathView
 {
 public:
-    QMathView(const QFont& font,
-              QDebug& error, QDebug& warning, QDebug& info, QDebug& debug);
+    QMathView(const QFont& font, const QLoggingCategory& category);
     ~QMathView();
     void loadURI(const char* mathml_url);
     void loadBuffer(const char* mathml_buf);

--- a/src/widget/QMathView.hh
+++ b/src/widget/QMathView.hh
@@ -1,0 +1,48 @@
+// Copyright (C) 2015 Yue Liu <yue.liu@mail.com>.
+//
+// This file is part of GtkMathView, a flexible, high-quality rendering
+// engine for MathML documents.
+//
+// GtkMathView is free software; you can redistribute it and/or modify it
+// either under the terms of the GNU Lesser General Public License version
+// 3 as published by the Free Software Foundation (the "LGPL") or, at your
+// option, under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation (the "GPL").  If you do not
+// alter this notice, a recipient may use your version of this file under
+// either the GPL or the LGPL.
+//
+// GtkMathView is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the LGPL or
+// the GPL for more details.
+//
+// You should have received a copy of the LGPL and of the GPL along with
+// this program in the files COPYING-LGPL-3 and COPYING-GPL-2; if not, see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef QMathView_hh
+#define QMathView_hh
+
+#include <QtCore/QSizeF>
+#include <QDebug>
+
+class QMathViewPrivate;
+class QPainter;
+
+class QMathView
+{
+public:
+    QMathView(const QFont& font,
+              QDebug& error, QDebug& warning, QDebug& info, QDebug& debug);
+    ~QMathView();
+    void loadURI(const char* mathml_url);
+    void loadBuffer(const char* mathml_buf);
+    void setFont(const QFont& font);
+    void update(QPainter* painter);
+    QSizeF sizeF() const;
+
+private:
+    QMathViewPrivate* const d;
+};
+
+#endif // QMathView_hh

--- a/src/widget/QMathView.hh
+++ b/src/widget/QMathView.hh
@@ -25,6 +25,7 @@
 
 #include <QtCore/QSizeF>
 #include <QLoggingCategory>
+#include <QColor>
 
 class QMathViewPrivate;
 class QPainter;
@@ -36,6 +37,8 @@ public:
     ~QMathView();
     void loadURI(const char* mathml_url);
     void loadBuffer(const char* mathml_buf);
+    void setForegroundColor(const QColor& color);
+    void setBackgroundColor(const QColor& color);
     void setFont(const QFont& font);
     void update(QPainter* painter);
     QSizeF sizeF() const;


### PR DESCRIPTION
Add a view interface QMathView so that qt applications using libmathview don't have to link to libmathview's dependencies or include their headers (harfbuzz, libxml2, etc.)